### PR TITLE
Fix Paragraph 84e video embed error

### DIFF
--- a/_posts/2024-03-28-blog-nppf-paragraph-84e-explained.md
+++ b/_posts/2024-03-28-blog-nppf-paragraph-84e-explained.md
@@ -13,8 +13,21 @@ comments: /thoughts/nppf-paragraph-84e-explained/
 ---
 
 <div class="videoWrapper">
-	<iframe src="https://www.youtube.com/embed/e1OGitGRWj0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen></iframe>
-</div> 
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/e1OGitGRWj0?rel=0&modestbranding=1"
+    title="NPPF Paragraph 84e planning legislation clause explained by Francis Terry and Martin Leay"
+    loading="lazy"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+    referrerpolicy="strict-origin-when-cross-origin"
+  ></iframe>
+</div>
+
+<p class="videoWrapper-fallback">
+  Can't see the video? <a href="https://www.youtube.com/watch?v=e1OGitGRWj0" rel="noopener" target="_blank">Watch it on YouTube</a>.
+</p>
+
 
 Many people, perhaps you, would love to build yourself a new house in the country where you could live with your family and work from home in rural tranquility. It is perhaps the English dream. The problem is getting planning permission. But don’t despair, NPPF paragraph 84e is the planning legislation which is specifically written to allow this to happen. The clause states that the new house has to be an ‘exceptional’ work of architecture and so it is not easy to get planning permission… but not impossible. In this video architect Francis Terry and planning specialist Martin Leay discuss how this can be done in practical terms using examples of their many past successes of ‘paragraph 84e’ houses.
 

--- a/_sass/_pages.scss
+++ b/_sass/_pages.scss
@@ -965,11 +965,15 @@ ul.publications p {
 	height: 0;
 }
 .videoWrapper iframe {
-	position: absolute;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 100%;
+}
+.videoWrapper-fallback {
+        margin-top: $unit;
+        text-align: center;
 }
 .erechtheion-video {
 	background: $black;

--- a/video-page-nppf-84e.md
+++ b/video-page-nppf-84e.md
@@ -9,5 +9,17 @@ article: article
 ---
 
 <div class="videoWrapper">
-	<iframe src="https://www.youtube.com/embed/e1OGitGRWj0" frameborder="0" allow="autoplay; encrypted-media" allowfullscreen alt="The NPPF paragraph 84e planning legislation clause explained by Francis Terry and Martin Leay discuss. The clause permits exceptional new houses in the country."></iframe>
+  <iframe
+    src="https://www.youtube-nocookie.com/embed/e1OGitGRWj0?rel=0&modestbranding=1"
+    title="NPPF Paragraph 84e planning legislation clause explained by Francis Terry and Martin Leay"
+    loading="lazy"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    allowfullscreen
+    referrerpolicy="strict-origin-when-cross-origin"
+  ></iframe>
 </div>
+
+<p class="videoWrapper-fallback">
+  Can't see the video? <a href="https://www.youtube.com/watch?v=e1OGitGRWj0" rel="noopener" target="_blank">Watch it on YouTube</a>.
+</p>


### PR DESCRIPTION
## Summary
- replace the Paragraph 84e video iframe with a privacy-enhanced embed configuration and fallback link
- mirror the updated embed in the related blog post so both pages share the same markup
- add styling for the fallback message that appears under embedded videos

## Testing
- not run (bundle install blocked by 403 Forbidden from rubygems)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6915c62418588326a6fc032a46e3a3af)